### PR TITLE
fix: update author name handling to use `raw_author_name`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ const fallbackTemplate = `---
 title: "{{ it.title }}"
 author:
 {{ @each(it.z_authors) => val, i }}
-  - "{{ val.given }} {{ val.family }}"
+  - "{{ val.raw_author_name }}"
 {{ /each }}
 doi: "{{ it.doi }}"
 url: "{{ it.doi_url }}"

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -14,8 +14,7 @@ interface UnpaywallResponse {
     url_for_pdf?: string;
   };
   z_authors: {
-    given: string;
-    family: string;
+    raw_author_name: string;
   }[];
   [key: string]: unknown;
 }

--- a/src/views/ReferencesModal.ts
+++ b/src/views/ReferencesModal.ts
@@ -20,7 +20,7 @@ export class ReferencesModal extends FuzzySuggestModal<Reference> {
     const { title, z_authors } = item.data;
     return `${title} - ${
       (z_authors || [])
-        .map((author) => `${author.given} ${author.family}`)
+        .map((author) => `${author.raw_author_name}`)
         .join(", ")
     }`;
   }


### PR DESCRIPTION
Unpaywall's author name field has changed:
https://unpaywall.org/data-format

Now using `raw_author_name` instead of `first`/`given`.